### PR TITLE
Clean up responses

### DIFF
--- a/src/flask_app.py
+++ b/src/flask_app.py
@@ -85,6 +85,11 @@ def api_game_new_guess(game_uuid):
       if current_guess in myCache.game_states[game_uuid].data['guess_history']:
           return {"error": "duplicate guess"}, 200
       guess_result = backend_run_game.process_new_guess(current_guess, myCache.game_states[game_uuid], all_words)
+      if "error" in guess_result:
+        if "not in dictionary" in guess_result["error"]:
+          return {"error":"word not in dictionary"}, 200
+        if "only letters" in guess_result["error"]:
+          return {"error":"word must be only letters"}, 200
       return {"success":"guess posted"}, 200
 
   elif request.form.get('guess') != None:


### PR DESCRIPTION

Addresses issue #26.
Relevant to issue #5. The API sends different responses now.

This PR improves responses. For POST requests, it responds with an HTTP response code and a brief message.
For GET requests, it responds with the game's public data, which now includes a field for the game's progress.
This also helps differentiate between errors related to the user input and the client's handling of the API.

- Include game status in JSON response
- Include game status and prevent duplicate guesses
- Only include HTTP response code for POST methods
- Include error codes for fake words and non-word guesses
