### PR TITLE
Accept custom solutions for newly created games

### DIFF
--- a/src/api/custom_word.py
+++ b/src/api/custom_word.py
@@ -1,0 +1,29 @@
+import re, random, json, requests
+import backend_setup, backend_create_new_game
+
+def set_custom_solution(game_state, new_solution, all_words):
+  # Error checking
+  # Game must exist
+  if game_state is None or game_state.data is None:
+    return {"error":"Game does not exist"}
+  # Game must not be in progress
+  if game_state.data['turn'] > 0:
+    return {"error":"Game already started"}
+  # New solution must be a valid word
+  if type(new_solution) != str:
+    return {"error":"new solution must be string"}
+  if len(new_solution) != 5:
+    return {"error":"Word must be 5 letters"}
+  pattern = re.compile("[A-Za-z]+")
+  if not pattern.fullmatch(new_solution):
+    return {"error":"Word must be only a-z letters."}
+  # Check if that is already the solution
+  if game_state.data['solution'] == new_solution:
+    return {"error":"Solution already set to that word."}
+  new_solution = str(new_solution)[:5].lower()
+  if new_solution not in list(all_words.values()):
+    print(new_solution, "was not in dictionary")
+    return {"error":"Solution is not in dictionary"}
+  game_state.data['solution'] = new_solution
+  return {"success":f"game solution set to {new_solution}"}
+

--- a/utils/test_dicts.py
+++ b/utils/test_dicts.py
@@ -1,0 +1,15 @@
+import backend_setup
+
+myCache, common_words, all_words = backend_setup.start_up_game_backend('a')
+
+print("testing")
+if "snaps" in list(common_words.values()):
+  print("commn")
+
+if "snaps" in all_words:
+  print("all")
+for x in list(common_words.values()):
+  if x not in list(all_words.values()):
+    print(x, "was in common words but not all_words")
+
+


### PR DESCRIPTION
The server can now change a game to have a custom solution when it
receives a POST request with a `"solution:<solution>"` key-value pair in
either Form data or JSON data.

This feature is accessible via 2 different endpoints. The first is,
`/v2/game/<game_uuid>/custom`, which is a new endpoint. It is also
accessible when a POST request sent to `/v1/game/<game_uuid>` contains a
`solution` key-value instead of a `guess` key-value. Note that a request
containing both `solution` and `guess` is rejected.
